### PR TITLE
Show username to which one is replying to.

### DIFF
--- a/src/discordclient.py
+++ b/src/discordclient.py
@@ -163,6 +163,10 @@ class DiscordClient(discord.Client):
                 await self.close()
                 return
 
+        try:
+            content = message.reference.resolved.author.display_name + ": " + content
+        except AttributeError:
+            pass  # Either the message as no reference, or it lacks its original message.
         """
         Send to IRC
         """


### PR DESCRIPTION
In case, discord-side, someone replies by making a reference to another message, translate it, irc-side, as simple text mention.

This ease understanding the conversations with an irc-only view.